### PR TITLE
Fix check for complete disagreement

### DIFF
--- a/R/Accessory.R
+++ b/R/Accessory.R
@@ -591,12 +591,24 @@ Theta.EAP <- function(IP, SE = TRUE, precision = 4, N.nodes = 30)
     data <- IP$data
     I    <- ncol(data)
     N    <- nrow(data)
-    # Discard response patterns due to complete disagreement:
-    rows.rm <- which(rowSums(data<2, na.rm = TRUE) + rowSums(is.na(data)) == I)
+    C    <- IP$C
+    # Discard response patterns due to complete disagreement;
+    # ceiling(C/2) gives for each item either the first agree category
+    # or the middle/neutral category (if one exists) --
+    # if a row has all responses as either missing or disagree,
+    # we want to remove that row.
+    # Note we use colSums(t(data) ...) rather than rowSums(data ...)
+    # for the first comparison so that vectorization over C
+    # coincides with the columns of the matrix
+    rows.rm <- which(colSums(t(data) < ceiling(C/2), na.rm = TRUE)
+		     + rowSums(is.na(data)) == I)
+    # If there are any such rows, we need to remove them;
+    # if there are no such rows, it's imperative we don't try to --
+    # if we do it will remove all such rows
     data.sv <- data
-    data    <- data[-rows.rm, ]
-    
-    C              <- IP$C
+    if ( length(rows.rm) > 0 ) {
+        data    <- data[-rows.rm, ]
+    }
     tmp            <- GGUM.data.condense(data)
     data.condensed <- tmp$data.condensed
     ind            <- tmp$ind

--- a/R/GGUM.R
+++ b/R/GGUM.R
@@ -98,10 +98,23 @@ GGUM <- function(data, C, SE = TRUE, precision = 4,
   # Sanity check - C:
   Sanity.C(C, I)
   
-  # Discard response patterns due to complete disagreement:
-  rows.rm <- which(rowSums(data<2, na.rm = TRUE) + rowSums(is.na(data)) == I)
+  # Discard response patterns due to complete disagreement;
+  # ceiling(C/2) gives for each item either the first agree category
+  # or the middle/neutral category (if one exists) --
+  # if a row has all responses as either missing or disagree,
+  # we want to remove that row.
+  # Note we use colSums(t(data) ...) rather than rowSums(data ...)
+  # for the first comparison so that vectorization over C
+  # coincides with the columns of the matrix
+  rows.rm <- which(colSums(t(data) < ceiling(C/2), na.rm = TRUE)
+                   + rowSums(is.na(data)) == I)
+  # If there are any such rows, we need to remove them;
+  # if there are no such rows, it's imperative we don't try to --
+  # if we do it will remove all such rows
   data.sv <- data
-  data    <- data[-rows.rm, ]
+  if ( length(rows.rm) > 0 ) {
+    data    <- data[-rows.rm, ]
+  }
   
   tmp            <- GGUM.data.condense(data)
   data.condensed <- tmp$data.condensed

--- a/R/GUM.R
+++ b/R/GUM.R
@@ -73,10 +73,23 @@ GUM <- function(data, C, SE = TRUE, precision = 4,
   # Sanity check - C:
   Sanity.C(C, I)
   
-  # Discard response patterns due to complete disagreement:
-  rows.rm <- which((rowSums(data<2, na.rm = TRUE) + rowSums(is.na(data))) == I)
+  # Discard response patterns due to complete disagreement;
+  # ceiling(C/2) gives for each item either the first agree category
+  # or the middle/neutral category (if one exists) --
+  # if a row has all responses as either missing or disagree,
+  # we want to remove that row.
+  # Note we use colSums(t(data) ...) rather than rowSums(data ...)
+  # for the first comparison so that vectorization over C
+  # coincides with the columns of the matrix
+  rows.rm <- which(colSums(t(data) < ceiling(C/2), na.rm = TRUE)
+                   + rowSums(is.na(data)) == I)
+  # If there are any such rows, we need to remove them;
+  # if there are no such rows, it's imperative we don't try to --
+  # if we do it will remove all such rows
   data.sv <- data
-  data    <- data[-rows.rm, ]
+  if ( length(rows.rm) > 0 ) {
+    data    <- data[-rows.rm, ]
+  }
   
   tmp            <- GGUM.data.condense(data)
   data.condensed <- tmp$data.condensed


### PR DESCRIPTION
As originally written, the check for complete disagreement had two issues:
(1) It assumed that responses less than 2 were disagreement,
    which may not be the case depending on C; and
(2) If no rows were found that needed to be removed,
    the check would actually remove all rows, resulting in an error.
This commit fixes both of these issues.

Rather than using 2 as the first response option that is not disagree,
it uses ceiling(C/2), which should be either the middle/neutral category,
or in the case of even C, the first agree category.

If no problematic rows are found, it skips the row removal step.