### PR TITLE
Fix bug reported in Issue #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 .Rproj
 .Rproj.user
 GGUM.Rproj
+simulationstudy_update.R

--- a/R/Accessory.R
+++ b/R/Accessory.R
@@ -628,7 +628,13 @@ Theta.EAP <- function(IP, SE = TRUE, precision = 4, N.nodes = 30)
     Th.condensed <- res
     Th.full      <- res[ind]
     Th.full.all  <- rep(NA, N)
-    Th.full.all[-rows.rm] <- Th.full
+    
+    if ( length(rows.rm) > 0 ) {
+      Th.full.all[-rows.rm] <- Th.full
+    }else{
+      Th.full.all <- Th.full
+    }
+    
     
     if (SE)
     {
@@ -639,7 +645,14 @@ Theta.EAP <- function(IP, SE = TRUE, precision = 4, N.nodes = 30)
       Th.SE.full  <- sqrt(num.SE / den)[ind]
       # 
       Th.SE.full.all           <- rep(NA, N)
-      Th.SE.full.all[-rows.rm] <- Th.SE.full
+      
+      if ( length(rows.rm) > 0 ) {
+        Th.SE.full.all[-rows.rm] <- Th.SE.full
+      }else{
+        Th.SE.full.all <- Th.SE.full
+      }
+      
+      
       
       return(cbind(
         Person   = (1:N), 

--- a/R/GGUM2004.R
+++ b/R/GGUM2004.R
@@ -106,7 +106,7 @@ write.GGUM2004 <- function(I, C, cutoff = 2, model = "GGUM",
             "50 NUMBER OF INNER CYCLES",
             "50 NUMBER OF FISHER SCORING ITERATIONS FOR THRESHOLDS",
             "50 NUMBER OF FISHER SCORING ITERATIONS FOR DELTAS & ALPHAS",
-            "0,001 CRITERION",
+            "0.001 CRITERION",
             "N WANT TO PLOT",
             "N WANT FIT STATISTICS")
   


### PR DESCRIPTION
I fixed a typo in the function write.GGUM2004, which set the convergence criterion to "0.000000" instead of "0.001".  

There was also a bug in the function Theta.EAP, which removed all rows when there were no patterns of complete disagreement. As a consequence, the matrix of the estimates of theta ended up full of NAs. This was fixed by including two if-else statements in the function.